### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pyspaces
 Works with Linux namespaces through glibc with pure python
 
-[![License](https://pypip.in/license/pyspaces/badge.svg)](https://pypi.python.org/pypi/pyspaces/)
-[![Latest Version](https://pypip.in/version/pyspaces/badge.svg)](https://pypi.python.org/pypi/pyspaces/)
-[![Downloads](https://pypip.in/download/pyspaces/badge.svg)](https://pypi.python.org/pypi/pyspaces/)
+[![License](https://img.shields.io/pypi/l/pyspaces.svg)](https://pypi.python.org/pypi/pyspaces/)
+[![Latest Version](https://img.shields.io/pypi/v/pyspaces.svg)](https://pypi.python.org/pypi/pyspaces/)
+[![Downloads](https://img.shields.io/pypi/dm/pyspaces.svg)](https://pypi.python.org/pypi/pyspaces/)
 [![Docs](https://readthedocs.org/projects/pyspaces/badge/)](https://pyspaces.readthedocs.org/en/latest/)
 
 discuss: [reddit](https://www.reddit.com/r/Python/comments/33z84l/linux_namespaces_througth_glibc_with_pure_python/), [habrahabr](http://habrahabr.ru/company/wargaming/blog/256647/)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyspaces))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyspaces`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.